### PR TITLE
Add JS helper to dynamically update favicon

### DIFF
--- a/Shared/MainLayout.razor
+++ b/Shared/MainLayout.razor
@@ -2,8 +2,6 @@
 
 @inherits LayoutComponentBase
 
-<link rel="icon" href="@AppState.FaviconUri" />
-
 <div hidden="@(AppState.IsSideNavHidden)" class="sidenav">
     <NavMenu />
 </div>

--- a/Shared/MainLayout.razor.cs
+++ b/Shared/MainLayout.razor.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using ExoKomodo.Config;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace ExoKomodo.Shared
 {
@@ -10,7 +12,7 @@ namespace ExoKomodo.Shared
         #region Member Methods
         public void Dispose()
         {
-            AppState.OnFaviconUriChange -= StateHasChanged;
+            AppState.OnFaviconUriChange -= UpdateFavicon;
             AppState.OnIsSideNavHiddenChange -= StateHasChanged;
         }
         #endregion
@@ -19,11 +21,22 @@ namespace ExoKomodo.Shared
 
         #region Protected
 
+        #region Members
+        [Inject]
+        protected IJSRuntime _jsRuntime { get; set; }
+        #endregion
+
         #region Member Methods
         protected override void OnInitialized()
         {
-            AppState.OnFaviconUriChange += StateHasChanged;
+            AppState.OnFaviconUriChange += UpdateFavicon;
             AppState.OnIsSideNavHiddenChange += StateHasChanged;
+        }
+
+        protected void UpdateFavicon()
+        {
+            _jsRuntime.InvokeVoidAsync("updateFavicon", AppState.FaviconUri);
+            StateHasChanged();
         }
         #endregion
 

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -12,6 +12,8 @@
     <script src="https://cdn.jsdelivr.net/npm/p5@1.1.9/lib/p5.js"></script>
     <script src="js/p5Wrapper.js"></script>
     <script src="js/browserHelpers.js"></script>
+
+    <link id="favicon" rel="icon"/>
 </head>
 
 <body>

--- a/wwwroot/js/browserHelpers.js
+++ b/wwwroot/js/browserHelpers.js
@@ -5,3 +5,17 @@ function loadFromLocalStorage(key) {
 function saveToLocalStorage(key, obj) {
     localStorage.setItem(key, JSON.stringify(obj));
 }
+
+function updateFavicon(faviconUri) {
+    let favicon = document.getElementById('favicon');
+    if (!favicon) {
+        console.error('Could not find favicon tag.');
+        return;
+    }
+    let href = favicon.getAttributeNode('href');
+    if (!href) {
+        href = document.createAttribute('href');
+        favicon.setAttributeNode(href);
+    }
+    href.value = faviconUri;
+}


### PR DESCRIPTION
Browsers like Chrome require that a favicon link be in the head to work properly.

Blazor does not allow data binding in the head tag, as this is considered static content.

By adding a JS helper to update the favicon at runtime, all browsers are compatible with the dynamic favicon. Any head content that needs to be dynamic should be handled in this way to maintain browser compatibilities.