### PR TITLE
Reference correct .NET directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           with:
             github_token: ${{ secrets.PUBLISH_TOKEN }}
             publish_branch: gh-pages
-            publish_dir: src/Client/bin/Release/net5.0/publish/wwwroot
+            publish_dir: src/Client/bin/Release/net6.0/publish/wwwroot
             allow_empty_commit: false
             keep_files: false
             force_orphan: true


### PR DESCRIPTION
net5.0 was still referenced in ci.yml, affecting the Github pages deployment